### PR TITLE
Make sure the account assigned to a player still is configured…

### DIFF
--- a/API.pm
+++ b/API.pm
@@ -52,12 +52,21 @@ sub getSomeUserId {
 	return $account;
 }
 
+sub getUserdata {
+	my ($class, $userId) = @_;
+
+	return unless $userId;
+
+	my $accounts = $prefs->get('accounts') || return;
+
+	return $accounts->{$userId};
+}
+
+# TODO - remove, as unused?
 sub getCountryCode {
 	my ($class, $userId) = @_;
-	my $accounts = $prefs->get('accounts') || {};
-
-	return 'US' unless $accounts && $userId && $accounts->{$userId};
-	return $accounts->{$userId}->{countryCode} || 'US';
+	my $userdata = $class->getUserdata($userId) || {};
+	return $userdata->{country} || 'US';
 }
 
 sub getFormat {
@@ -112,9 +121,9 @@ sub typeOfItem {
 
 sub cacheTrackMetadata {
 	my ($class, $tracks, $params) = @_;
-	
+
 	return [] unless $tracks;
-	
+
 	return [ map {
 		my $entry = $_;
 		my $oldMeta = $cache->get( 'deezer_meta_' . $entry->{id}) || {};
@@ -136,7 +145,7 @@ sub cacheTrackMetadata {
 			tracknum => $entry->{track_position},
 			link => $entry->{link},
 		};
-		
+
 		# make sure we won't come back
 		$meta->{_complete} = 1 if $meta->{tracknum} || ($params && $params->{cache});
 
@@ -149,7 +158,7 @@ sub cacheTrackMetadata {
 
 sub cacheEpisodeMetadata {
 	my ($class, $episodes, $params) = @_;
-	
+
 	return [] unless $episodes;
 	$params ||= {};
 
@@ -171,7 +180,7 @@ sub cacheEpisodeMetadata {
 			comment => $entry->{description},
 			date => substr($entry->{release_date}, 0, 10),
 		};
-		
+
 		# make sure we won't come back
 		$meta->{_complete} = 1 if $meta->{album} || $params->{cache};
 

--- a/API/Async.pm
+++ b/API/Async.pm
@@ -476,8 +476,7 @@ sub getCollectionFingerprint {
 sub updateFavorite {
 	my ($self, $cb, $action, $type, $id) = @_;
 
-	my $accounts = $prefs->get('accounts') || {};
-	my $profile  = $accounts->{$self->userId};
+	my $profile = Plugins::Deezer::API->getUserdata($self->userId);
 	my $access_token = $profile->{token} if $profile;
 
 	# well... we have a trailing 's' (I know this is hacky... and bad)
@@ -639,9 +638,8 @@ sub _getProviders {
 sub _getUserContext {
 	my ($self, $cb) = @_;
 
-	my $accounts = $prefs->get('accounts') || {};
-	my $profile  = $accounts->{$self->userId};
-	my $arl = $profile->{arl};
+	my $profile = Plugins::Deezer::API->getUserdata($self->userId);
+	my $arl = $profile->{arl} if $profile;
 
 	return $self->_getTokens( $cb, { arl => $arl } ) if $arl && $profile->{status} == 2;
 
@@ -747,8 +745,7 @@ sub _get {
 	my $ttl = delete $params->{_ttl} || DEFAULT_TTL;
 	my $noCache = delete $params->{_nocache};
 
-	my $accounts = $prefs->get('accounts') || {};
-	my $profile  = $accounts->{$self->userId};
+	my $profile  = Plugins::Deezer::API->getUserdata($self->userId);
 
 	$params->{access_token} = $profile->{token};
 	$params->{limit} ||= DEFAULT_LIMIT;

--- a/API/Sync.pm
+++ b/API/Sync.pm
@@ -36,7 +36,7 @@ sub getFavorites {
 
 		$item;
 	} @{$result->{data} || []} ] if $result;
-	
+
 	return $items;
 }
 
@@ -64,7 +64,7 @@ sub playlist {
 	my $tracks = Plugins::Deezer::API->cacheTrackMetadata( [ grep {
 			$_->{type} && $_->{type} eq 'track'
 	} @{$playlist->{data} || []} ]) if $playlist;
-	
+
 	return $tracks;
 }
 
@@ -80,13 +80,12 @@ sub _get {
 	my ( $class, $url, $userId, $params ) = @_;
 
 	$userId ||= Plugins::Deezer::API->getSomeUserId();
-	
+
 	$params ||= {};
 	$params->{limit} ||= DEFAULT_LIMIT;
-	
+
 	if ($userId) {
-		my $accounts = $prefs->get('accounts') || {};
-		my $profile  = $accounts->{$userId};
+		my $profile  = Plugins::Deezer::API->getUserdata($userId) || {};
 		$params->{access_token} = $profile->{token};
 	}
 
@@ -105,7 +104,7 @@ sub _get {
 
 		$@ && $log->error($@);
 		main::DEBUGLOG && $log->is_debug && $log->debug(Data::Dump::dump($result));
-		
+
 		# see note on the Async version
 
 		if (ref $result eq 'HASH' && $result->{data} && $result->{total}) {

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -836,7 +836,7 @@ sub _renderArtist {
 		name => cstring($client, 'ALBUMS'),
 		url => \&getArtistAlbums,
 		image => 'html/images/albums.png',
-		passthrough => [ { 
+		passthrough => [ {
 			id => $item->{id},
 			name => $item->{name},
 		} ],
@@ -966,8 +966,10 @@ sub getAPIHandler {
 		$api = $client->pluginData('api');
 
 		if ( !$api ) {
+			my $userdata = Plugins::TIDAL::API->getUserdata($prefs->client($client)->get('userId'));
+
 			# if there's no account assigned to the player, just pick one
-			if ( !$prefs->client($client)->get('userId') ) {
+			if ( !$userdata ) {
 				my $userId = Plugins::Deezer::API->getSomeUserId();
 				$prefs->client($client)->set('userId', $userId) if $userId;
 			}


### PR DESCRIPTION
Otherwise fall back to the first existing account.

This is an issue I've faced with TIDAL, too: a user has multiple accounts in LMS. Then removes one. But it remains assigned to a player. The old code would continue to try to use that now removed account, and there's no way to select the remaining account. With my change in this situation the player would automatically get the remaining account assigned.

Re-use the newly introduced `getUseradata()` in some other places where we need to access a user's account.