### PR TITLE
Fix authentication issues by using Windows user agent

### DIFF
--- a/API/Auth.pm
+++ b/API/Auth.pm
@@ -24,6 +24,10 @@ our ($serial, $cbc);
 my $cbcRetry = 30;
 my (%waiters);
 
+# Define a robust desktop User-Agent string.
+my $desktopUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+my %headers   = ( "User-Agent" => $desktopUA );
+
 sub page { Slim::Web::HTTP::CSRF->protectURI('plugins/Deezer/auth.html') }
 
 sub init {
@@ -60,14 +64,14 @@ sub _getCBC {
 					$log->warn("Fail to get bootstrapped $url ($_[1]), retrying in $cbcRetry sec");
 					$cbcRetry *= 2;
 				}
-			)->get($url);
+            )->get($url, %headers);
 		},
 		sub {
 			Slim::Utils::Timers::setTimer(undef, time() + $cbcRetry, \&_getCBC);
 			$log->warn("Fail to get jumpstart ($_[1]), retrying in $cbcRetry sec");
 			$cbcRetry *= 2;
 		}
-	)->get('https://www.deezer.com/en/channels/explore');
+    )->get('https://www.deezer.com/en/channels/explore', %headers);
 }
 
 sub authRegister {


### PR DESCRIPTION
Problem:
- Deezer authentication was failing on my Android 7 and Android 8 smartphones
- The website was detecting mobile devices and sending unexpected HTML
- Encrypted Deezer songs were played

Solution:
- Modified the HTTP requests to use a Windows Chrome user agent
- Specifically used 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36'

Benefits:
- Successfully authenticates on Android smartphones
- May help other mobile platforms having similar issues