### PR TITLE
Fix/correct duplicate 'method =>' typo in liveStream GW API call

### DIFF
--- a/Custom.pm
+++ b/Custom.pm
@@ -449,7 +449,12 @@ sub liveStream {
 		my $urls = $result->{results}->{LIVESTREAM_URLS}->{data} if $result->{results}->{LIVESTREAM_URLS};
 		$cb->($urls);
 	}, {
-		method => method => 'livestream.getData',
+		# Fix (issue #54): the previous `method => method => 'livestream.getData'`
+		# was a typo. Perl's fat-comma auto-quotes the left side, so that expression
+		# produced { method => 'method', 'livestream.getData' => undef }, causing
+		# the GW API to be called with method name "method" and returning
+		# "Method unknown: method".
+		method => 'livestream.getData',
 	}, {
 		livestream_id => $id,
 		supported_codecs => ['mp3', 'aac'],


### PR DESCRIPTION
**Disclaimer:**

**All code-changes have been made with Claude-code.**

## Fix: Deezer Radio always failing with "Method unknown: method"

Deezer Radio / livestream playback has never worked due to a one-word typo in the GW API call inside `liveStream()`. Every attempt to play a radio station produced the error `Method unknown: method` and stopped after a few seconds.

### Root cause

In `Custom.pm`, the `liveStream()` function contained a duplicate `method =>` fat-comma expression. In Perl, the fat-comma operator `=>` auto-quotes its left operand (a bareword), so the duplicate produced a 3-element list instead of a key-value pair. The resulting hash contained the method name `"method"` instead of `"livestream.getData"`. Deezer responded with `Method unknown: method` because no API method by that name exists.

### Fix

Remove the duplicate `method =>` so the GW API is called with the correct method name `"livestream.getData"`.

Verified working: radio stations now resolve to a real stream URL and play correctly.

Fixes #54
